### PR TITLE
derivationOrigin

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -183,14 +183,14 @@ const authStates: MachineConfig<RootContext, any, RootEvent> = {
           }
           const result = await provider.connect()
           result.match(() => {
-              callback({
-                type: "CONNECT_DONE",
-                data: {
-                  activeProvider: provider,
-                  principal: provider.principal!,
-                },
-              })
-            },
+            callback({
+              type: "CONNECT_DONE",
+              data: {
+                activeProvider: provider,
+                principal: provider.principal!,
+              },
+            })
+          },
             (e) => {
               console.error(e)
               callback({
@@ -260,6 +260,7 @@ type Config = {
   ledgerCanisterId?: string
   ledgerHost?: string
   appName?: string
+  derivationOrigin?: string;
 }
 
 type ClientOptions = {
@@ -279,6 +280,7 @@ type ClientOptions = {
     ledgerHost?: string
     appName?: string
     customDomain?: string
+    derivationOrigin?: string;
   }
 }
 
@@ -341,10 +343,10 @@ class Client {
 }
 
 const createClient = ({
-                        canisters = {},
-                        providers: p = [],
-                        globalProviderConfig = {},
-                      }: ClientOptions) => {
+  canisters = {},
+  providers: p = [],
+  globalProviderConfig = {},
+}: ClientOptions) => {
   const config = {
     dev: true,
     autoConnect: true,

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -23,6 +23,7 @@ type Config = {
   ledgerHost?: string
   appName?: string
   delegationModes?: Array<DelegationMode>
+  derivationOrigin?: string
 }
 
 let isICX = !!window.icx

--- a/packages/core/src/providers/internet-identity.ts
+++ b/packages/core/src/providers/internet-identity.ts
@@ -30,6 +30,7 @@ class InternetIdentity implements IConnector {
     host: string,
     providerUrl: string,
     dev: boolean,
+    derivationOrigin?: string,
   }
   #identity?: Identity
   #principal?: string
@@ -124,6 +125,7 @@ class InternetIdentity implements IConnector {
           identityProvider: this.#config.providerUrl,
           onSuccess: resolve,
           onError: reject,
+          derivationOrigin: this.#config.derivationOrigin,
         })
       })
       const identity = this.#client?.getIdentity()

--- a/packages/core/src/providers/nfid.ts
+++ b/packages/core/src/providers/nfid.ts
@@ -30,6 +30,7 @@ class NFID implements IConnector {
     host: string,
     providerUrl: string,
     dev: Boolean,
+    derivationOrigin?: string,
   }
   #identity?: any
   #principal?: string
@@ -129,6 +130,7 @@ class NFID implements IConnector {
           identityProvider: this.#config.providerUrl + `/authenticate/?applicationName=${this.#config.appName}`,
           onSuccess: resolve,
           onError: reject,
+          derivationOrigin: this.#config.derivationOrigin,
         })
       })
       const identity = this.#client.getIdentity()


### PR DESCRIPTION
Added derivation origins for modclub.app to use connect2ic library. 

Without support for derivationOrigins property for custom domains, modclub.app would generate a different principalId than https://canister-id.ic0.io. This would lead to users creating a new account depending on the address they logged into. 